### PR TITLE
fix/obstacle_segmenation_pcd_type_updater

### DIFF
--- a/pcd_type_updater/pyproject.toml
+++ b/pcd_type_updater/pyproject.toml
@@ -9,10 +9,11 @@ readme = "README.md"
 python = "^3.10"
 transforms3d = "^0.4.2"
 pyyaml = "^6.0.1"
-plotly = "^5.22.0"
+plotly = "^6.1.1"
 pandas = "^2.2.2"
-kaleido = "^0.2.1"
+kaleido = "^1.0.0"
 autoware_msg_bag_converter = {git = "ssh://git@github.com/hayato-m126/autoware_msg_bag_converter.git", rev = "main"}
+nuscenes-devkit = ">=1.1.9,<1.2.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
■**Issue/ 課題**
 1. When installing poetry when updating pcd type、kaleido is failed to install. 
      <img width="2336" height="763" alt="image" src="https://github.com/user-attachments/assets/7ba66ad2-f27f-4d25-baed-e74ed95da6f9" />

 2. No data occurs when running Evaluator. matplotlib error also occurs.

■**Cause / 原因** 
 1. kaleido version（0.2.1）is needed to upgrade. 
 2. The nuscenes-devkit version causes crashes related to matplotlib.

■**Solution / 解決方法** 
1. Upgraded the version of kaleido from 0.2.1 to 1.0.0. And, plotly is also upgraded from 5.22.0 to 6.1.1. 
2. Add nuscenes-devkit = ">=1.1.9,<1.2.0"
Ref : https://github.com/tier4/driving_log_replayer_v2/blob/exp/obstacle_segmentation_multipolygon/requirements.txt

■**Evaluator Test Result / 動作確認結果** 
https://evaluation.ci.tier4.jp/evaluation/reports/c82c0619-e1b4-5778-8c08-d29ed58aa9fc?project_id=autoware_dev

